### PR TITLE
Fix bestAttemptContent accessor

### DIFF
--- a/EmarsysNotificationService.podspec
+++ b/EmarsysNotificationService.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 	spec.name                 = 'EmarsysNotificationService'
-	spec.version              = '2.4.0'
+	spec.version              = '2.4.1'
 	spec.homepage             = 'https://github.com/emartech/ios-emarsys-sdk'
 	spec.license              = 'Mozilla Public License 2.0'
     spec.author               = { 'Emarsys Technologies' => 'mobile-team@emarsys.com' }

--- a/Sources/MobileEngage/RichNotificationExtension/EMSNotificationService.m
+++ b/Sources/MobileEngage/RichNotificationExtension/EMSNotificationService.m
@@ -21,7 +21,7 @@ typedef void(^ContentHandler)(UNNotificationContent *contentToDeliver);
 - (void)didReceiveNotificationRequest:(UNNotificationRequest *)request
                    withContentHandler:(void (^)(UNNotificationContent *_Nonnull))contentHandler {
     self.contentHandler = contentHandler;
-    _bestAttemptContent = (UNMutableNotificationContent *) [request.content mutableCopy];
+    self.bestAttemptContent = (UNMutableNotificationContent *) [request.content mutableCopy];
 
     if (!self.bestAttemptContent) {
         contentHandler(request.content);


### PR DESCRIPTION
The use of _bestAttemptContent  in this case causes the next check self.bestAttemptContent always returns FALSE for me. Changed to self.bestAttemptContent always works.
This bug prevents any rich push notifications come to iOS, image will be ignored, just displaying title and body.

Hope you can take a look at this soon!

Danny