### PR TITLE
Fix deadlock in operationQueue, when turn off wifi

### DIFF
--- a/Sources/Core/ConnectionWatchdog/EMSConnectionWatchdog.m
+++ b/Sources/Core/ConnectionWatchdog/EMSConnectionWatchdog.m
@@ -60,16 +60,18 @@
 - (void)startObserving {
     __weak typeof(self) weakSelf = self;
     [self.operationQueue addOperationWithBlock:^{
-        weakSelf.notificationToken = [[NSNotificationCenter defaultCenter] addObserverForName:kEMSReachabilityChangedNotification
-                                                                                       object:nil
-                                                                                        queue:weakSelf.operationQueue
-                                                                                   usingBlock:^(NSNotification *note) {
-                                                                                       EMSNetworkStatus connectionStatus = [note.object currentReachabilityStatus];
-                                                                                       BOOL connected = connectionStatus == ReachableViaWiFi || connectionStatus == ReachableViaWWAN;
-                                                                                       [weakSelf.connectionChangeListener connectionChangedToNetworkStatus:connectionStatus
-                                                                                                                                          connectionStatus:connected];
-                                                                                   }];
-    }];
+        weakSelf.notificationToken = [
+            [NSNotificationCenter defaultCenter] addObserverForName:kEMSReachabilityChangedNotification
+            object:nil
+            queue:nil
+            usingBlock:^(NSNotification *note) {
+                EMSNetworkStatus connectionStatus = [note.object currentReachabilityStatus];
+                BOOL connected = connectionStatus == ReachableViaWiFi || connectionStatus == ReachableViaWWAN;
+                [weakSelf.connectionChangeListener connectionChangedToNetworkStatus:connectionStatus
+                                                                   connectionStatus:connected];
+            }];
+    }
+    ];
     dispatch_async(dispatch_get_main_queue(), ^{
         [weakSelf.reachability startNotifier];
     });


### PR DESCRIPTION
After turning off the WIFI network, the operation block is triggered, but it also blocks itself. https://github.com/louiswoodsUZ/ios-emarsys-sdk also faced this problem as well, but he did not find a solution 

There is screenshot
<a href="https://ibb.co/CWJcDGH"><img src="https://i.ibb.co/CWJcDGH/2022-04-21-00-26-41.png" alt="2022-04-21-00-26-41" border="0"></a>